### PR TITLE
[ENG-58] - Updated json Gem to 2.6.2 for Braavos

### DIFF
--- a/intuit-oauth.gemspec
+++ b/intuit-oauth.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'httparty', '~> 0.18.0'
-  spec.add_dependency 'json', '~> 1.8.3'
+  spec.add_dependency 'json', '~> 2.6.2'
   # spec.add_dependency 'json_web_token', '~> 0.3.5'
   spec.add_dependency 'rsa-pem-from-mod-exp', '~> 0.1.0'
 


### PR DESCRIPTION
## Ticket
[ENG-58](https://fundthrough.atlassian.net/browse/ENG-58)

## Changes
- Updated `json` gem from version `1.8.3` to `2.6.2` since braavos requires updated json version.

## Definition of Done
- [ ] Pull request is up to date with the destination branch
- [ ] Commits were squashed
- [ ] All Tests are passing
- [ ] At least one code review
- [ ] Screen-Review passed and logged.
